### PR TITLE
Move tableC code out of class, spell tariff right. Touch tableC-lcoe,…

### DIFF
--- a/PowerPlant.py
+++ b/PowerPlant.py
@@ -108,31 +108,6 @@ class PowerPlant(Investment):
         # Fixme: once TableC is no regression, use /MWh for integer
         return display_as(result, 'USD/kWh')
 
-    def table_LCOE(self, feedin_tariff, discount_rate, tax_rate, depreciation_period):
-        def printRowInt(label, quantity):
-            print('{:30}{:8.0f}'.format(label, quantity))
-
-        def printRowFloat(label, value):
-            print('{:30}{:8.4f}'.format(label, value))
-
-        def printRowNPV(label, vector):
-            printRowInt(label, npv(discount_rate, vector))
-
-        print("Levelized cost of electricity -", self.name, "\n")
-        printRowInt("Investment", self.capital)
-        printRowNPV("Fuel cost", self.fuel_cost())
-        printRowNPV("O&M cost", self.operation_maintenance_cost())
-        printRowNPV("Tax", self.income_tax(feedin_tariff, tax_rate, depreciation_period))
-        printRowNPV("Sum of costs", self.cash_out(feedin_tariff,
-                                                  tax_rate,
-                                                  depreciation_period))
-        printRowNPV("Electricity produced", self.power_generation)
-        printRowFloat("LCOE", self.lcoe(feedin_tariff,
-                                        discount_rate,
-                                        tax_rate,
-                                        depreciation_period))
-        print('')
-
 
 class CofiringPlant(PowerPlant):
 
@@ -282,7 +257,7 @@ class CofiringPlant(PowerPlant):
 
     def CO2_npv(self, discount_rate, specific_cost):
         df = self.emission_reduction(specific_cost)
-        v = df['CO2']['Benefit']
+        v = df['CO2']['Benefit']  # FIXME: use .loc
         value = npv(discount_rate, v)
         return display_as(value, 'kUSD')
 
@@ -291,35 +266,3 @@ class CofiringPlant(PowerPlant):
         v = df.ix['Benefit'].drop('CO2').sum()
         value = npv(discount_rate, v)
         return display_as(value, 'kUSD')
-
-    def tableC(self, feedin_tariff, discount_rate, tax_rate, depreciation_period):
-        def printRowInt(label, quantity):
-            print('{:30}{:8.0f}'.format(label, quantity))
-
-        def printRowFloat(label, value):
-            print('{:30}{:8.4f}'.format(label, value))
-
-        def printRowNPV(label, vector):
-            printRowInt(label, npv(discount_rate, vector))
-
-        print("Levelized cost of electricity - ", self.name, "\n")
-        printRowInt("Investment", self.capital)
-        printRowNPV("Fuel cost", self.fuel_cost())
-        printRowNPV("  Coal", self.coal_cost())
-        printRowNPV("  Biomass", self.straw_supply.cost(self.biomass.price))
-        printRowNPV("    transportation", self.straw_supply.transport_cost())
-        printRowNPV("    straw at field", self.straw_supply.field_cost(self.biomass.price))
-        printRowNPV("O&M cost", self.operation_maintenance_cost())
-        printRowNPV("  coal", self.coal_om_cost())
-        printRowNPV("  biomass", self.biomass_om_cost())
-        printRowNPV("Tax", self.income_tax(feedin_tariff,
-                                           tax_rate,
-                                           depreciation_period))
-        printRowNPV("Sum of costs", self.cash_out(feedin_tariff,
-                                                  tax_rate,
-                                                  depreciation_period))
-        printRowNPV("Electricity produced", self.power_generation)
-        printRowFloat("LCOE", self.lcoe(feedin_tariff,
-                                        discount_rate,
-                                        tax_rate,
-                                        depreciation_period))

--- a/figure3.py
+++ b/figure3.py
@@ -14,7 +14,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 from init import USD
-from parameters import discount_rate, tax_rate, depreciation_period, feedin_tarif
+from parameters import discount_rate, tax_rate, depreciation_period, feedin_tariff
 from parameters import MongDuong1, MongDuong1Cofire, NinhBinh, NinhBinhCofire
 from parameters import straw, specific_cost
 
@@ -46,9 +46,9 @@ def benefit_array(plant, cofiringplant, income_parameter):
 index = np.arange(5)
 width = 0.4
 plt.figure(figsize=(10, 5))
-NB = plt.barh(index + width, benefit_array(NinhBinh, NinhBinhCofire, feedin_tarif['NB']), width,
+NB = plt.barh(index + width, benefit_array(NinhBinh, NinhBinhCofire, feedin_tariff['NB']), width,
               color='#ff4500', edgecolor='none', label='Ninh Binh')
-MD = plt.barh(index, benefit_array(MongDuong1, MongDuong1Cofire, feedin_tarif['MD']), width,
+MD = plt.barh(index, benefit_array(MongDuong1, MongDuong1Cofire, feedin_tariff['MD']), width,
               color='navy', edgecolor='none', label='Mong Duong 1')
 plt.xlabel('Cumulative benefit over 20 years (M$)')
 plt.yticks(index + 0.5, ('Plant owner\n(net profit)',

--- a/parameters.py
+++ b/parameters.py
@@ -33,7 +33,7 @@ from SupplyChain import SupplyChain, SupplyZone
 discount_rate = 0.087771
 depreciation_period = 10
 tax_rate = 0.25  # Corporate tax in Vietnam
-feedin_tarif = {'MD': 1239.17 * VND / kWh, 'NB': 1665.6 * VND / kWh}
+feedin_tariff = {'MD': 1239.17 * VND / kWh, 'NB': 1665.6 * VND / kWh}
 
 straw_burn_rate = 0.9  # Percentage of straw burned infield after harvest
 

--- a/tableA-NPV.py
+++ b/tableA-NPV.py
@@ -10,10 +10,9 @@
 #
 """ Details the net present value calculations """
 
-from parameters import MongDuong1, NinhBinh, MongDuong1Cofire, NinhBinhCofire
-from parameters import feedin_tarif
-from parameters import discount_rate, depreciation_period, tax_rate
 from init import time_horizon
+from parameters import MongDuong1, NinhBinh, MongDuong1Cofire, NinhBinhCofire
+from parameters import feedin_tariff, discount_rate, depreciation_period, tax_rate
 
 print('')
 
@@ -22,14 +21,14 @@ print('Discount Rate', discount_rate)
 print('Depreciation', depreciation_period, 'years')
 
 print('')
-print('FIT', feedin_tarif['MD'])
-MongDuong1.pretty_table(feedin_tarif['MD'], discount_rate, tax_rate, depreciation_period)
+print('FIT', feedin_tariff['MD'])
+MongDuong1.pretty_table(feedin_tariff['MD'], discount_rate, tax_rate, depreciation_period)
 
-MongDuong1Cofire.pretty_table(feedin_tarif['MD'], discount_rate, tax_rate, depreciation_period)
+MongDuong1Cofire.pretty_table(feedin_tariff['MD'], discount_rate, tax_rate, depreciation_period)
 
 print('')
 
-print('FIT', feedin_tarif['NB'])
-NinhBinh.pretty_table(feedin_tarif['NB'], discount_rate, tax_rate, depreciation_period)
+print('FIT', feedin_tariff['NB'])
+NinhBinh.pretty_table(feedin_tariff['NB'], discount_rate, tax_rate, depreciation_period)
 
-NinhBinhCofire.pretty_table(feedin_tarif['NB'], discount_rate, tax_rate, depreciation_period)
+NinhBinhCofire.pretty_table(feedin_tariff['NB'], discount_rate, tax_rate, depreciation_period)

--- a/tableC-LCOE.py
+++ b/tableC-LCOE.py
@@ -9,16 +9,54 @@
 #
 #
 """Compares the LCOE with and without cofiring"""
+from natu.numpy import npv
 
 from parameters import MongDuong1, MongDuong1Cofire, NinhBinh, NinhBinhCofire
-from parameters import discount_rate, tax_rate, depreciation_period, feedin_tarif
+from parameters import discount_rate, tax_rate, depreciation_period, feedin_tariff
+from PowerPlant import CofiringPlant
 
-MongDuong1.table_LCOE(feedin_tarif['MD'], discount_rate, tax_rate, depreciation_period)
 
-MongDuong1Cofire.tableC(feedin_tarif['MD'], discount_rate, tax_rate, depreciation_period)
+def tableC(plant, tariff):
+    def printRowInt(label, quantity):
+        print('{:30}{:8.0f}'.format(label, quantity))
+
+    def printRowFloat(label, value):
+        print('{:30}{:8.4f}'.format(label, value))
+
+    def printRowNPV(label, vector):
+        printRowInt(label, npv(discount_rate, vector))
+
+    print("Levelized cost of electricity - " + plant.name + "\n")
+    printRowInt("Investment", plant.capital)
+    printRowNPV("Fuel cost", plant.fuel_cost())
+    if isinstance(plant, CofiringPlant):
+        printRowNPV("  Coal", plant.coal_cost())
+        printRowNPV("  Biomass", plant.straw_supply.cost(plant.biomass.price))
+        printRowNPV("    transportation", plant.straw_supply.transport_cost())
+        printRowNPV("    straw at field", plant.straw_supply.field_cost(plant.biomass.price))
+    printRowNPV("O&M cost", plant.operation_maintenance_cost())
+    if isinstance(plant, CofiringPlant):
+        printRowNPV("  coal", plant.coal_om_cost())
+        printRowNPV("  biomass", plant.biomass_om_cost())
+    printRowNPV("Tax", plant.income_tax(tariff,
+                                        tax_rate,
+                                        depreciation_period))
+    printRowNPV("Sum of costs", plant.cash_out(tariff,
+                                               tax_rate,
+                                               depreciation_period))
+    printRowNPV("Electricity produced", plant.power_generation)
+    printRowFloat("LCOE", plant.lcoe(tariff,
+                                     discount_rate,
+                                     tax_rate,
+                                     depreciation_period))
+
+
+tableC(MongDuong1, feedin_tariff['MD'])
+print('')
+tableC(MongDuong1Cofire, feedin_tariff['MD'])
 
 print('')
 
-NinhBinh.table_LCOE(feedin_tarif['NB'], discount_rate, tax_rate, depreciation_period)
-
-NinhBinhCofire.tableC(feedin_tarif['NB'], discount_rate, tax_rate, depreciation_period)
+tableC(NinhBinh, feedin_tariff['NB'])
+print('')
+tableC(NinhBinhCofire, feedin_tariff['NB'])


### PR DESCRIPTION
Reduces duplication and simplifies the class, to get an "A" on codacy.
It would probalby be better to recode all tables as dataframes. Let's be content with good enough as is for now. We will have opportunities to revise.